### PR TITLE
add method-signature-style tselint rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -67,6 +67,7 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/consistent-generic-constructors": "warn",
+      "@typescript-eslint/method-signature-style": ["error", "property"],
       "@typescript-eslint/no-confusing-non-null-assertion": ["error"],
       "@typescript-eslint/no-confusing-void-expression": [
         "error",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "preserve",
+    "module": "preserve", // because we build with tsx now
     "target": "es2022",
     "lib": ["es2022"],
     "esModuleInterop": true,


### PR DESCRIPTION
See https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful for rationale